### PR TITLE
verifier: better overflow handling & support for ctx type

### DIFF
--- a/lib/bpf.c
+++ b/lib/bpf.c
@@ -305,8 +305,8 @@ ubpf_adjust_head(void* ctx, int offset) {
 struct ubpf_func_proto ubpf_adjust_head_proto = {
     .func = (ext_func)ubpf_adjust_head,
     .arg_types = {
-            0xff,
-            0xff,
+            CTX_PTR,
+            IMM,
             0xff,
             0xff,
             0xff,
@@ -318,7 +318,7 @@ struct ubpf_func_proto ubpf_adjust_head_proto = {
             0xff,
             0xff,
     },
-    .ret = UNKNOWN,
+    .ret = PKT_PTR,
 };
 
 void *
@@ -331,20 +331,20 @@ ubpf_packet_data(void *ctx)
 struct ubpf_func_proto ubpf_packet_data_proto = {
     .func = (ext_func)ubpf_packet_data,
     .arg_types = {
-            PKT_PTR,
+            CTX_PTR,
             0xff,
             0xff,
             0xff,
             0xff,
     },
     .arg_sizes = {
-            SIZE_PTR_MAX,
+            0xff,
             0xff,
             0xff,
             0xff,
             0xff,
     },
-    .ret = UNKNOWN,
+    .ret = PKT_PTR,
 };
 
 static uint32_t
@@ -383,7 +383,7 @@ register_functions(struct ubpf_vm *vm)
     ubpf_register_function(vm, 5, "ubpf_time_get_ns", ubpf_time_get_ns_proto);
     ubpf_register_function(vm, 6, "ubpf_hash", ubpf_hash_proto);
     ubpf_register_function(vm, 7, "ubpf_printf", ubpf_printf_proto);
-    ubpf_register_function(vm, 8, "ubpf_adjust_head", ubpf_adjust_head_proto);
+    ubpf_register_function(vm, UBPF_ADJUST_HEAD_ID, "ubpf_adjust_head", ubpf_adjust_head_proto);
     ubpf_register_function(vm, 9, "ubpf_packet_data", ubpf_packet_data_proto);
     ubpf_register_function(vm, 10, "ubpf_get_rss_hash", ubpf_get_rss_hash_proto);
 }

--- a/lib/bpf/ubpf_int.h
+++ b/lib/bpf/ubpf_int.h
@@ -25,6 +25,7 @@
 #define STACK_SIZE 1024
 #define NB_FUNC_ARGS 5
 #define MAX_SIZE_ARG 8
+#define UBPF_ADJUST_HEAD_ID 8
 
 struct ebpf_inst;
 typedef uint64_t (*ext_func)(uint64_t arg0, uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4);
@@ -39,6 +40,7 @@ enum ubpf_reg_type {
     PKT_PTR       = 32,
     PKT_SIZE      = 64,
     STACK_PTR     = 128,
+    CTX_PTR       = 256,
 };
 
 enum ubpf_arg_size {

--- a/lib/bpf/ubpf_int.h
+++ b/lib/bpf/ubpf_int.h
@@ -26,6 +26,7 @@
 #define NB_FUNC_ARGS 5
 #define MAX_SIZE_ARG 8
 #define UBPF_ADJUST_HEAD_ID 8
+#define BPF_PSEUDO_MAP_FD 1
 
 struct ebpf_inst;
 typedef uint64_t (*ext_func)(uint64_t arg0, uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4);

--- a/lib/bpf/ubpf_loader.c
+++ b/lib/bpf/ubpf_loader.c
@@ -304,8 +304,11 @@ ubpf_load_elf(struct ubpf_vm *vm, const void *elf, size_t elf_size, char **errms
                         }
                     }
 
-                    *(uint32_t *)((uint64_t)text_copy + r->r_offset + 4) = (uint32_t)((uint64_t)map);
-                    *(uint32_t *)((uint64_t)text_copy + r->r_offset + sizeof(struct ebpf_inst) + 4) = (uint32_t)((uint64_t)map >> 32);
+                    struct ebpf_inst *inst1 = text_copy + r->r_offset;
+                    inst1->src = BPF_PSEUDO_MAP_FD;
+                    inst1->imm = (uint32_t)((uint64_t)map);
+                    struct ebpf_inst *inst2 = inst1 + 1;
+                    inst2->imm = (uint32_t)((uint64_t)map >> 32);
 
                 } else if (sym_shndx == str_shndx) {
                     if (!str_shndx) {

--- a/lib/bpf/ubpf_vm.c
+++ b/lib/bpf/ubpf_vm.c
@@ -1403,9 +1403,7 @@ validate_alu_op(struct bpf_state *state, struct ebpf_inst *inst,
                   dst_reg->u.min, dst_reg->u.max);
             break;
 
-        default:
-            update_min_max_alu_op(state->regs, inst);
-
+        default: {
             uint8_t op = EBPF_OP(inst->opcode);
             if ((op == EBPF_ALU_SUB || op == EBPF_ALU_ADD)
                 && dst_reg->type == STACK_PTR
@@ -1428,6 +1426,9 @@ validate_alu_op(struct bpf_state *state, struct ebpf_inst *inst,
                                      state->instno);
                 return false;
             }
+
+            update_min_max_alu_op(state->regs, inst);
+        }
     }
 
     return true;

--- a/lib/bpf/ubpf_vm.c
+++ b/lib/bpf/ubpf_vm.c
@@ -1329,12 +1329,6 @@ validate_mem_access(struct bpf_state *state, uint8_t regno,
 
     switch (state->regs[regno].type) {
         case PKT_PTR:
-//            if (t == WRITE) {
-//                *errmsg = ubpf_error("forbidden write to packet at PC %d",
-//                                     state->instno);
-//                return false;
-//            }
-
             min_val = state->regs[regno].s.min;
             max_val = state->regs[regno].u.max;
 


### PR DESCRIPTION
This pull request contains a series of patches to allow your latest examples to work with the uBPF verifier. The first patch reworks the overflow handling to allow for larger ranges of values. The second cleans up some commented code prohibiting packet writes, used for Oko, but not needed anymore. The third fixes examples so that they implement the appropriate checks on packet lengths (those were inverted). The last patch adds support for a new `CTX_PTR` type and uses it to recognize helpers `ubpf_packet_data` and `ubpf_adjust_head`.

I haven't implemented support for bit shifts in the first patch. I remember there were some issues with that some time ago, so if you get an example program that doesn't pass the verifier because of that, please send it to me. Adding support shouldn't be too difficult.

In some cases, the length checks in the example programs may not be needed anymore. As long as you write within the added bytes at the beginning of the packet, checks are not needed. The verifier recognizes calls to `ubpf_adjust_head` and adjusts the packet bounds accordingly.

I've taken this opportunity to fix a few warnings in the verifier's code. There are many remaining warnings in the codebase though.