### PR TITLE
Implement configuration flag to disable BPF verifier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ P4rt-OVS works only with the userspace datapath of OVS. Currently, there are two
 of userspace datapath: DPDK and AF_XDP. We tested P4rt-OVS with both solutions. However, we recommend AF_XDP as a more
 lightweight solution.
 
+**Note!** P4rt-OVS allows to disable BPF verifier, but it is not recommended to do so. Please, use it carefully and only for testing or research purpose.
+If BPF verifier is disabled it is higly recommended to generate data plane programs from the P4 language, because `p4c-ubpf` generates verified programs.
+To disable BPF verifier add `--disable-bpf-verifier` flag to configuration script:
+
+```bash
+./configure --disable-bpf-verifier
+```
+
 ### DPDK
 
 To install P4rt-OVS on top of DPDK, you can follow the usual [guidelines to install Open

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -301,6 +301,24 @@ AC_DEFUN([OVS_CHECK_LINUX_AF_XDP], [
   AM_CONDITIONAL([HAVE_AF_XDP], test "$AF_XDP_ENABLE" = true)
 ])
 
+dnl OVS_DISABLE_BPF_VERIFIER
+dnl
+dnl Disable BPF verifier
+AC_DEFUN([OVS_DISABLE_BPF_VERIFIER], [
+  AC_ARG_ENABLE([bpf-verifier],
+               [AC_HELP_STRING([--disable-bpf-verifier], [Disable BPF verifier])],
+               [disable_bpf_verifier=yes], [])
+  AC_MSG_CHECKING([whether BPF verifier is enabled])
+  if test "$disable_bpf_verifier" != yes; then
+    AC_MSG_RESULT([yes])
+    AC_DEFINE([HAVE_BPF_VERIFIER], [1],
+                  [Define to 1 if BPF verifier enabled.])
+  else
+    AC_MSG_RESULT([no])
+  fi
+  AM_CONDITIONAL([HAVE_BPF_VERIFIER], test "disable_bpf_verifier" = no)
+])
+
 dnl OVS_CHECK_DPDK
 dnl
 dnl Configure DPDK source tree

--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,7 @@ OVS_CHECK_DOT
 OVS_CHECK_IF_DL
 OVS_CHECK_STRTOK_R
 OVS_CHECK_LINUX_AF_XDP
+OVS_DISABLE_BPF_VERIFIER
 AC_CHECK_DECLS([sys_siglist], [], [], [[#include <signal.h>]])
 AC_CHECK_MEMBERS([struct stat.st_mtim.tv_nsec, struct stat.st_mtimensec],
   [], [], [[#include <sys/stat.h>]])

--- a/lib/bpf/ubpf_vm.c
+++ b/lib/bpf/ubpf_vm.c
@@ -222,9 +222,11 @@ ubpf_load(struct ubpf_vm *vm, const void *code, uint32_t code_len, char **errmsg
         return -1;
     }
 
+    #ifdef HAVE_BPF_VERIFIER
     if (!validate(vm, code, code_len/8, errmsg)) {
         return -1;
     }
+    #endif
 
     vm->insts = xmalloc(code_len);
 


### PR DESCRIPTION
This PR implements changes that allow to disable BPF verifier (not recommended, but sometimes useful).